### PR TITLE
Fix: Address APU audio generation issues

### DIFF
--- a/src/main/java/core/apu/APU.java
+++ b/src/main/java/core/apu/APU.java
@@ -65,18 +65,39 @@ public class APU {
         try {
             AudioFormat audioFormat = new AudioFormat(SAMPLE_RATE, SAMPLE_SIZE_IN_BITS, CHANNELS, SIGNED, BIG_ENDIAN);
             DataLine.Info info = new DataLine.Info(SourceDataLine.class, audioFormat);
+
             if (!AudioSystem.isLineSupported(info)) {
-                System.err.println("Audio line not supported: " + audioFormat);
-                return;
+                // Log a clear error message
+                String errorMessage = "Audio line not supported for format: " + audioFormat;
+                System.err.println("APU Error: " + errorMessage);
+                // Throw a runtime exception
+                throw new RuntimeException(errorMessage);
             }
+
             sourceDataLine = (SourceDataLine) AudioSystem.getLine(info);
             sourceDataLine.open(audioFormat);
             sourceDataLine.start();
-            System.out.println("SourceDataLine initialized and started for APU.");
+            System.out.println("APU: SourceDataLine initialized and started successfully.");
+
         } catch (LineUnavailableException e) {
+            // Log a clear error message
+            String errorMessage = "Audio line unavailable: " + e.getMessage();
+            System.err.println("APU Error: " + errorMessage);
+            e.printStackTrace(); // Keep original stack trace for debugging
+            // Re-throw the exception as a runtime exception
+            throw new RuntimeException("Failed to initialize audio line due to LineUnavailableException", e);
+        } catch (SecurityException e) {
+            // Catch potential SecurityExceptions if audio system access is restricted
+            String errorMessage = "Audio system access denied: " + e.getMessage();
+            System.err.println("APU Error: " + errorMessage);
             e.printStackTrace();
-            // Handle appropriately - e.g., disable audio, log error
-            sourceDataLine = null;
+            throw new RuntimeException("Failed to initialize audio line due to SecurityException", e);
+        } catch (IllegalArgumentException e) {
+            // Catch potential IllegalArgumentExceptions from AudioFormat or other setup
+            String errorMessage = "Illegal argument during audio setup: " + e.getMessage();
+            System.err.println("APU Error: " + errorMessage);
+            e.printStackTrace();
+            throw new RuntimeException("Failed to initialize audio line due to IllegalArgumentException", e);
         }
         this.frameSequenceCounter = 0;
         this.frameStep = 0;


### PR DESCRIPTION
This commit resolves several issues related to "no audio yet" behavior in the APU implementation.

TriangleChannel:
- `clock()`: Ensures `timerValue` is decremented every CPU cycle. When `timerValue` is zero, it's reloaded with `timerPeriod+1`. `sequencePosition` advancement is now gated by `lengthCounter > 0` and `linearCounter > 0`.
- `setEnabled(true)`: Now correctly reloads `lengthCounter` from the `lengthCounterLoad` value.
- `updateTimerPeriod()`:
    - Added a warning log when the effective timer period (T) is set to 0.
    - If `timerValue` is 0 when the period is updated, `timerValue` is reset to the new `internalTimerPeriod` to prevent timer stalls given the new `clock()` logic.
- No unused `internalTimerPeriod` field was found for removal; it is actively used.

APU:
- Hardened `AudioSystem` initialization in the constructor:
    - `LineUnavailableException` during `AudioSystem.getLine()` is no longer silently ignored.
    - Clear logging is added for audio line errors (e.g., "Audio line not supported", "Audio line unavailable").
    - These exceptions are now re-thrown as `RuntimeException` to ensure `sourceDataLine` is never null before use and to make initialization failures prominent.

CPU:
- Verified that `apu.clock()` is invoked exactly once per CPU cycle in the `runCycle()` method within `CPU.java`. No changes were necessary.

APU Register Writes:
- Confirmed that existing logging in `APU.writeRegister()` for writes to $4015 (channel enable) and $4017 (frame counter) is sufficient for debugging purposes.
- Ensured that enabling a channel correctly reloads its length counter (TriangleChannel) and allows the linear counter to function as intended.